### PR TITLE
Add possibility to create factories without subclassing.

### DIFF
--- a/Code/IntermoduleDataTransfer/RamblerViperModuleTransitionHandlerProtocol.h
+++ b/Code/IntermoduleDataTransfer/RamblerViperModuleTransitionHandlerProtocol.h
@@ -11,6 +11,7 @@
 @protocol RamblerViperModuleInput;
 @class RamblerViperModuleFactory;
 @protocol RamblerViperModuleTransitionHandlerProtocol;
+@protocol RamblerViperModuleFactoryProtocol;
 
 typedef void (^ModuleTransitionBlock)(id<RamblerViperModuleTransitionHandlerProtocol> sourceModuleTransitionHandler,
                                       id<RamblerViperModuleTransitionHandlerProtocol> destinationModuleTransitionHandler);
@@ -30,7 +31,7 @@ typedef void (^ModuleTransitionBlock)(id<RamblerViperModuleTransitionHandlerProt
 // Method opens module using segue
 - (RamblerViperOpenModulePromise*)openModuleUsingSegue:(NSString*)segueIdentifier;
 // Method opens module using module factory
-- (RamblerViperOpenModulePromise*)openModuleUsingFactory:(RamblerViperModuleFactory *)moduleFactory withTransitionBlock:(ModuleTransitionBlock)transitionBlock;
+- (RamblerViperOpenModulePromise*)openModuleUsingFactory:(id <RamblerViperModuleFactoryProtocol>)moduleFactory withTransitionBlock:(ModuleTransitionBlock)transitionBlock;
 // Method removes/closes module
 - (void)closeCurrentModule:(BOOL)animated;
 

--- a/Code/IntermoduleDataTransfer/UIViewController+RamblerViperModuleTransitionHandlerProtocol.m
+++ b/Code/IntermoduleDataTransfer/UIViewController+RamblerViperModuleTransitionHandlerProtocol.m
@@ -54,7 +54,7 @@ static IMP originalPrepareForSegueMethodImp;
 }
 
 // Method opens module using module factory
-- (RamblerViperOpenModulePromise*)openModuleUsingFactory:(RamblerViperModuleFactory *)moduleFactory withTransitionBlock:(ModuleTransitionBlock)transitionBlock {
+- (RamblerViperOpenModulePromise*)openModuleUsingFactory:(id <RamblerViperModuleFactoryProtocol>)moduleFactory withTransitionBlock:(ModuleTransitionBlock)transitionBlock {
     RamblerViperOpenModulePromise *openModulePromise = [[RamblerViperOpenModulePromise alloc] init];
     id<RamblerViperModuleTransitionHandlerProtocol> destinationModuleTransitionHandler = [moduleFactory instantiateModuleTransitionHandler];
     id<RamblerViperModuleInput> moduleInput = nil;


### PR DESCRIPTION
Change 'openModuleUsingFactory:withTransitionBlock:' parameter type from concrete factory class to generic class conforming to the factory protocol. 

This change allows to create and use other factories without subclassing.
