### PR TITLE
Another implementation of view factory without storyboard

### DIFF
--- a/Code/IntermoduleDataTransfer/RamblerViperModuleFactory.h
+++ b/Code/IntermoduleDataTransfer/RamblerViperModuleFactory.h
@@ -14,6 +14,8 @@
 @interface RamblerViperModuleFactory : NSObject<RamblerViperModuleFactoryProtocol>
 
 - (instancetype)initWithStoryboard:(UIStoryboard*)storyboard andRestorationId:(NSString*)restorationId;
+- (instancetype)initWithViewHandler:(id<RamblerViperModuleTransitionHandlerProtocol>(^)(void))viewHandler;
+
 @property (nonatomic,strong,readonly) UIStoryboard *storyboard;
 @property (nonatomic,strong,readonly) NSString* restorationId;
 

--- a/Code/IntermoduleDataTransfer/RamblerViperModuleFactory.m
+++ b/Code/IntermoduleDataTransfer/RamblerViperModuleFactory.m
@@ -12,6 +12,7 @@
 
 @property (nonatomic,strong) UIStoryboard *storyboard;
 @property (nonatomic,strong) NSString* restorationId;
+@property (nonatomic,copy) id<RamblerViperModuleTransitionHandlerProtocol>(^viewHandler)(void);
 
 @end
 
@@ -26,9 +27,21 @@
     return self;
 }
 
+- (instancetype)initWithViewHandler:(id<RamblerViperModuleTransitionHandlerProtocol>(^)(void))viewHandler {
+    self = [super init];
+    if (self) {
+        self.viewHandler = viewHandler;
+    }
+    return self;
+}
+
 #pragma mark - RDSModuleFactoryProtocol
 
 - (__nullable id<RamblerViperModuleTransitionHandlerProtocol>)instantiateModuleTransitionHandler {
+    if (self.viewHandler) {
+        return self.viewHandler();
+    }
+    
     id<RamblerViperModuleTransitionHandlerProtocol> destinationViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.restorationId];
     return destinationViewController;
 }


### PR DESCRIPTION
Hello,
this solution more flexibility and shorten than previous (with target@action)

Usage example:

``` objective-c
- (id<RamblerViperModuleFactoryProtocol>)factoryWithoutStoryboardBetaModule {
    return [TyphoonDefinition withClass:[RamblerViperModuleFactory class]
                          configuration:^(TyphoonDefinition *definition) {
                              [definition useInitializer:@selector(initWithViewHandler:)
                                              parameters:^(TyphoonMethod *initializer) {
                                                  [initializer injectParameterWith:^id<RamblerViperModuleTransitionHandlerProtocol>(void) {
                                                      return [self viewRamblerModuleBeta];
                                                  }];
                                              }];
                          }];
}
```
