### PR TITLE
Add ability to use TyphoonNibLoader

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,7 +7,7 @@ platform :ios, '8.0'
 
 def appPods
     pod "ViperMcFlurry", :path => "../ViperMcFlurry.podspec"
-    pod "Typhoon", '~> 3.2.0'
+    pod "Typhoon", '~> 4.0.0'
 end
 
 target 'ViperMcFlurry_Example' do

--- a/Example/ViperMcFlurry.xcodeproj/project.pbxproj
+++ b/Example/ViperMcFlurry.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		429835341E2E835700DB54EC /* RamblerModuleGammaPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352A1E2E835700DB54EC /* RamblerModuleGammaPresenter.m */; };
 		429835351E2E835700DB54EC /* RamblerModuleGammaRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352C1E2E835700DB54EC /* RamblerModuleGammaRouter.m */; };
 		429835361E2E835700DB54EC /* RamblerModuleGammaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */; };
+		4298353C1E2E8FFE00DB54EC /* RamblerModuleGammaViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4298353B1E2E8FFE00DB54EC /* RamblerModuleGammaViewController.xib */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -99,6 +100,7 @@
 		4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaViewController.m; sourceTree = "<group>"; };
 		429835301E2E835700DB54EC /* RamblerModuleGammaViewInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaViewInput.h; sourceTree = "<group>"; };
 		429835311E2E835700DB54EC /* RamblerModuleGammaViewOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaViewOutput.h; sourceTree = "<group>"; };
+		4298353B1E2E8FFE00DB54EC /* RamblerModuleGammaViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RamblerModuleGammaViewController.xib; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* ViperMcFlurry_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ViperMcFlurry_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -290,6 +292,7 @@
 				4298352E1E2E835700DB54EC /* RamblerModuleGammaViewController.h */,
 				4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */,
 				429835301E2E835700DB54EC /* RamblerModuleGammaViewInput.h */,
+				4298353B1E2E8FFE00DB54EC /* RamblerModuleGammaViewController.xib */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -490,9 +493,6 @@
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Egor Tolstoy";
 				TargetAttributes = {
-					6003F589195388D20070C39A = {
-						DevelopmentTeam = RU64C364MT;
-					};
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;
 					};
@@ -523,6 +523,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
+				4298353C1E2E8FFE00DB54EC /* RamblerModuleGammaViewController.xib in Resources */,
 				D24D49071BD4C9ED00C77475 /* LaunchScreen.storyboard in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
 				6003F598195388D20070C39A /* InfoPlist.strings in Resources */,
@@ -802,7 +803,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = RU64C364MT;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ViperMcFlurry/ViperMcFlurry-Prefix.pch";
@@ -822,7 +823,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = RU64C364MT;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ViperMcFlurry/ViperMcFlurry-Prefix.pch";

--- a/Example/ViperMcFlurry.xcodeproj/project.pbxproj
+++ b/Example/ViperMcFlurry.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		162C73431B78A45F00226B47 /* RamblerModuleBetaRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C733A1B78A45F00226B47 /* RamblerModuleBetaRouter.m */; };
 		162C73441B78A45F00226B47 /* RamblerModuleBetaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C733D1B78A45F00226B47 /* RamblerModuleBetaViewController.m */; };
 		2F8EC9FE21353262E6D3028E /* Pods_ViperMcFlurry_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F6F5979FBF96E09EF139449 /* Pods_ViperMcFlurry_Tests.framework */; };
+		429835321E2E835700DB54EC /* RamblerModuleGammaInteractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 429835241E2E835700DB54EC /* RamblerModuleGammaInteractor.m */; };
+		429835331E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = 429835281E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.m */; };
+		429835341E2E835700DB54EC /* RamblerModuleGammaPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352A1E2E835700DB54EC /* RamblerModuleGammaPresenter.m */; };
+		429835351E2E835700DB54EC /* RamblerModuleGammaRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352C1E2E835700DB54EC /* RamblerModuleGammaRouter.m */; };
+		429835361E2E835700DB54EC /* RamblerModuleGammaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -78,6 +83,22 @@
 		29CC82345586C4F662E7C65C /* Pods-ViperMcFlurry_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.release.xcconfig"; sourceTree = "<group>"; };
 		3E218B7F42124CFBDB835247 /* Pods-ViperMcFlurry_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		3F6F5979FBF96E09EF139449 /* Pods_ViperMcFlurry_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ViperMcFlurry_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		429835221E2E835700DB54EC /* RamblerModuleGammaInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaInput.h; sourceTree = "<group>"; };
+		429835231E2E835700DB54EC /* RamblerModuleGammaInteractor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaInteractor.h; sourceTree = "<group>"; };
+		429835241E2E835700DB54EC /* RamblerModuleGammaInteractor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaInteractor.m; sourceTree = "<group>"; };
+		429835251E2E835700DB54EC /* RamblerModuleGammaInteractorInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaInteractorInput.h; sourceTree = "<group>"; };
+		429835261E2E835700DB54EC /* RamblerModuleGammaInteractorOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaInteractorOutput.h; sourceTree = "<group>"; };
+		429835271E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaModuleAssembly.h; sourceTree = "<group>"; };
+		429835281E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaModuleAssembly.m; sourceTree = "<group>"; };
+		429835291E2E835700DB54EC /* RamblerModuleGammaPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaPresenter.h; sourceTree = "<group>"; };
+		4298352A1E2E835700DB54EC /* RamblerModuleGammaPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaPresenter.m; sourceTree = "<group>"; };
+		4298352B1E2E835700DB54EC /* RamblerModuleGammaRouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaRouter.h; sourceTree = "<group>"; };
+		4298352C1E2E835700DB54EC /* RamblerModuleGammaRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaRouter.m; sourceTree = "<group>"; };
+		4298352D1E2E835700DB54EC /* RamblerModuleGammaRouterInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaRouterInput.h; sourceTree = "<group>"; };
+		4298352E1E2E835700DB54EC /* RamblerModuleGammaViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaViewController.h; sourceTree = "<group>"; };
+		4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RamblerModuleGammaViewController.m; sourceTree = "<group>"; };
+		429835301E2E835700DB54EC /* RamblerModuleGammaViewInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaViewInput.h; sourceTree = "<group>"; };
+		429835311E2E835700DB54EC /* RamblerModuleGammaViewOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RamblerModuleGammaViewOutput.h; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* ViperMcFlurry_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ViperMcFlurry_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -133,6 +154,7 @@
 		162C73141B789B6800226B47 /* Viper */ = {
 			isa = PBXGroup;
 			children = (
+				429835211E2E835700DB54EC /* ModuleGamma */,
 				162C732A1B789D6F00226B47 /* ModuleBeta */,
 				162C73151B789D3200226B47 /* ModuleAlpha */,
 			);
@@ -244,6 +266,62 @@
 				162C73391B78A45F00226B47 /* RamblerModuleBetaRouter.h */,
 				162C733A1B78A45F00226B47 /* RamblerModuleBetaRouter.m */,
 				162C733B1B78A45F00226B47 /* RamblerModuleBetaRouterInput.h */,
+			);
+			name = Router;
+			sourceTree = "<group>";
+		};
+		429835211E2E835700DB54EC /* ModuleGamma */ = {
+			isa = PBXGroup;
+			children = (
+				429835271E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.h */,
+				429835281E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.m */,
+				429835371E2E847200DB54EC /* View */,
+				429835381E2E848C00DB54EC /* Interactor */,
+				429835391E2E84A100DB54EC /* Presenter */,
+				4298353A1E2E84B500DB54EC /* Router */,
+			);
+			name = ModuleGamma;
+			path = Viper/ModuleGamma;
+			sourceTree = "<group>";
+		};
+		429835371E2E847200DB54EC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4298352E1E2E835700DB54EC /* RamblerModuleGammaViewController.h */,
+				4298352F1E2E835700DB54EC /* RamblerModuleGammaViewController.m */,
+				429835301E2E835700DB54EC /* RamblerModuleGammaViewInput.h */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		429835381E2E848C00DB54EC /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				429835231E2E835700DB54EC /* RamblerModuleGammaInteractor.h */,
+				429835241E2E835700DB54EC /* RamblerModuleGammaInteractor.m */,
+				429835251E2E835700DB54EC /* RamblerModuleGammaInteractorInput.h */,
+			);
+			name = Interactor;
+			sourceTree = "<group>";
+		};
+		429835391E2E84A100DB54EC /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				429835261E2E835700DB54EC /* RamblerModuleGammaInteractorOutput.h */,
+				429835291E2E835700DB54EC /* RamblerModuleGammaPresenter.h */,
+				4298352A1E2E835700DB54EC /* RamblerModuleGammaPresenter.m */,
+				429835311E2E835700DB54EC /* RamblerModuleGammaViewOutput.h */,
+				429835221E2E835700DB54EC /* RamblerModuleGammaInput.h */,
+			);
+			name = Presenter;
+			sourceTree = "<group>";
+		};
+		4298353A1E2E84B500DB54EC /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				4298352B1E2E835700DB54EC /* RamblerModuleGammaRouter.h */,
+				4298352C1E2E835700DB54EC /* RamblerModuleGammaRouter.m */,
+				4298352D1E2E835700DB54EC /* RamblerModuleGammaRouterInput.h */,
 			);
 			name = Router;
 			sourceTree = "<group>";
@@ -590,14 +668,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				162C73421B78A45F00226B47 /* RamblerModuleBetaPresenter.m in Sources */,
+				429835341E2E835700DB54EC /* RamblerModuleGammaPresenter.m in Sources */,
 				162C73291B789D6700226B47 /* RamblerModuleAlphaViewController.m in Sources */,
 				162C73251B789D6700226B47 /* RamblerModuleAlphaInteractor.m in Sources */,
 				162C73271B789D6700226B47 /* RamblerModuleAlphaPresenter.m in Sources */,
 				D24D49051BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m in Sources */,
+				429835331E2E835700DB54EC /* RamblerModuleGammaModuleAssembly.m in Sources */,
+				429835321E2E835700DB54EC /* RamblerModuleGammaInteractor.m in Sources */,
 				162C73431B78A45F00226B47 /* RamblerModuleBetaRouter.m in Sources */,
 				162C73441B78A45F00226B47 /* RamblerModuleBetaViewController.m in Sources */,
+				429835361E2E835700DB54EC /* RamblerModuleGammaViewController.m in Sources */,
 				6003F59E195388D20070C39A /* RamblerAppDelegate.m in Sources */,
 				162C73401B78A45F00226B47 /* RamblerModuleBetaInteractor.m in Sources */,
+				429835351E2E835700DB54EC /* RamblerModuleGammaRouter.m in Sources */,
 				D24D49021BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m in Sources */,
 				162C73281B789D6700226B47 /* RamblerModuleAlphaRouter.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,

--- a/Example/ViperMcFlurry.xcodeproj/project.pbxproj
+++ b/Example/ViperMcFlurry.xcodeproj/project.pbxproj
@@ -1,2123 +1,831 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>01BC9CB6C6F4D26F423048A6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>138D895A56E50306869154A6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>162C73141B789B6800226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C732A1B789D6F00226B47</string>
-				<string>162C73151B789D3200226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Viper</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73151B789D3200226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>D24D49031BD1049E00C77475</string>
-				<string>D24D49041BD1049E00C77475</string>
-				<string>162C732B1B789D7900226B47</string>
-				<string>162C732E1B789D8B00226B47</string>
-				<string>162C732D1B789D8400226B47</string>
-				<string>162C732C1B789D7E00226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ModuleAlpha</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73161B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaInteractor.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaInteractor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73171B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaInteractor.m</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaInteractor.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73181B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaInteractorInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaInteractorInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73191B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaInteractorOutput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaInteractorOutput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C731C1B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaPresenter.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaPresenter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C731D1B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaPresenter.m</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaPresenter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C731E1B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaRouter.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaRouter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C731F1B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaRouter.m</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaRouter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73201B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaRouterInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaRouterInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73211B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaViewController.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73221B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaViewController.m</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73231B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaViewInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaViewInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73241B789D6700226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaViewOutput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaViewOutput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73251B789D6700226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C73171B789D6700226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73271B789D6700226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C731D1B789D6700226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73281B789D6700226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C731F1B789D6700226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73291B789D6700226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C73221B789D6700226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C732A1B789D6F00226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>D24D49001BD1049400C77475</string>
-				<string>D24D49011BD1049400C77475</string>
-				<string>162C73451B78A46400226B47</string>
-				<string>162C73471B78A47E00226B47</string>
-				<string>162C73461B78A47800226B47</string>
-				<string>162C73481B78A48400226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ModuleBeta</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C732B1B789D7900226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73211B789D6700226B47</string>
-				<string>162C73221B789D6700226B47</string>
-				<string>162C73231B789D6700226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>View</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C732C1B789D7E00226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C731E1B789D6700226B47</string>
-				<string>162C731F1B789D6700226B47</string>
-				<string>162C73201B789D6700226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Router</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C732D1B789D8400226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73191B789D6700226B47</string>
-				<string>162C73241B789D6700226B47</string>
-				<string>162C731C1B789D6700226B47</string>
-				<string>162C731D1B789D6700226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Presenter</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C732E1B789D8B00226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73161B789D6700226B47</string>
-				<string>162C73171B789D6700226B47</string>
-				<string>162C73181B789D6700226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Interactor</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C732F1B789EA100226B47</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>archive.ar</string>
-			<key>name</key>
-			<string>libPods-ViperMcFlurry_Example.a</string>
-			<key>path</key>
-			<string>Pods/../build/Debug-iphoneos/libPods-ViperMcFlurry_Example.a</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73311B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaInteractor.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaInteractor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73321B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleBetaInteractor.m</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaInteractor.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73331B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaInteractorInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaInteractorInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73341B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaInteractorOutput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaInteractorOutput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73371B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaPresenter.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaPresenter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73381B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleBetaPresenter.m</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaPresenter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73391B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaRouter.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaRouter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733A1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleBetaRouter.m</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaRouter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733B1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaRouterInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaRouterInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733C1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaViewController.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733D1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleBetaViewController.m</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733E1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaViewInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaViewInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C733F1B78A45F00226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaViewOutput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaViewOutput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73401B78A45F00226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C73321B78A45F00226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73421B78A45F00226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C73381B78A45F00226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73431B78A45F00226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C733A1B78A45F00226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73441B78A45F00226B47</key>
-		<dict>
-			<key>fileRef</key>
-			<string>162C733D1B78A45F00226B47</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>162C73451B78A46400226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C733E1B78A45F00226B47</string>
-				<string>162C733C1B78A45F00226B47</string>
-				<string>162C733D1B78A45F00226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>View</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73461B78A47800226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73341B78A45F00226B47</string>
-				<string>162C73371B78A45F00226B47</string>
-				<string>162C73381B78A45F00226B47</string>
-				<string>162C733F1B78A45F00226B47</string>
-				<string>162C73491B78A4A500226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Presenter</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73471B78A47E00226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73311B78A45F00226B47</string>
-				<string>162C73321B78A45F00226B47</string>
-				<string>162C73331B78A45F00226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Interactor</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73481B78A48400226B47</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73391B78A45F00226B47</string>
-				<string>162C733A1B78A45F00226B47</string>
-				<string>162C733B1B78A45F00226B47</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Router</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>162C73491B78A4A500226B47</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaInput.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaInput.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>169FC0D71B95C86E008547D7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>ViperMcFlurry-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>169FC0D81B95C86E008547D7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ViperMcFlurry-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>29585292F60D04C0C6BFE358</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>LICENSE</string>
-			<key>path</key>
-			<string>../LICENSE</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>29A94EBD936C47E4D47A9A6C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>29CC82345586C4F662E7C65C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ViperMcFlurry_Example.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2F8EC9FE21353262E6D3028E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3F6F5979FBF96E09EF139449</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3E218B7F42124CFBDB835247</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ViperMcFlurry_Example.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3F6F5979FBF96E09EF139449</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods_ViperMcFlurry_Tests.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4D62E5BDBFF12E6425C93A40</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>3E218B7F42124CFBDB835247</string>
-				<string>29CC82345586C4F662E7C65C</string>
-				<string>9DB79ED922F73E404786FD30</string>
-				<string>F7BF77682AD97D2B0DE14324</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5FB186E48B14A2189DA1EA83</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>6003F581195388D10070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>60FF7A9C1954A5C5007DD14C</string>
-				<string>6003F593195388D20070C39A</string>
-				<string>6003F5B5195388D20070C39A</string>
-				<string>6003F58C195388D20070C39A</string>
-				<string>6003F58B195388D20070C39A</string>
-				<string>4D62E5BDBFF12E6425C93A40</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F582195388D10070C39A</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>Rambler</string>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Egor Tolstoy</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>6003F5AD195388D20070C39A</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>6003F589195388D20070C39A</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>6003F585195388D10070C39A</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-				<string>Base</string>
-			</array>
-			<key>mainGroup</key>
-			<string>6003F581195388D10070C39A</string>
-			<key>productRefGroup</key>
-			<string>6003F58B195388D20070C39A</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>6003F589195388D20070C39A</string>
-				<string>6003F5AD195388D20070C39A</string>
-			</array>
-		</dict>
-		<key>6003F585195388D10070C39A</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>6003F5BD195388D20070C39A</string>
-				<string>6003F5BE195388D20070C39A</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6003F586195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>162C73421B78A45F00226B47</string>
-				<string>162C73291B789D6700226B47</string>
-				<string>162C73251B789D6700226B47</string>
-				<string>162C73271B789D6700226B47</string>
-				<string>D24D49051BD1049E00C77475</string>
-				<string>162C73431B78A45F00226B47</string>
-				<string>162C73441B78A45F00226B47</string>
-				<string>6003F59E195388D20070C39A</string>
-				<string>162C73401B78A45F00226B47</string>
-				<string>D24D49021BD1049400C77475</string>
-				<string>162C73281B789D6700226B47</string>
-				<string>6003F59A195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F587195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6003F590195388D20070C39A</string>
-				<string>6003F592195388D20070C39A</string>
-				<string>6003F58E195388D20070C39A</string>
-				<string>C2C905018238A19115ED6AC6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F588195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>873B8AEB1B1F5CCA007FD442</string>
-				<string>D24D49071BD4C9ED00C77475</string>
-				<string>6003F5A9195388D20070C39A</string>
-				<string>6003F598195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F589195388D20070C39A</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>6003F5BF195388D20070C39A</string>
-			<key>buildPhases</key>
-			<array>
-				<string>AEB035DEF2B1E52B5823E72B</string>
-				<string>6003F586195388D20070C39A</string>
-				<string>6003F587195388D20070C39A</string>
-				<string>6003F588195388D20070C39A</string>
-				<string>C6050BAFABC07C78254F390F</string>
-				<string>01BC9CB6C6F4D26F423048A6</string>
-				<string>9E0EE8EC6CC5F15FDF605C15</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>ViperMcFlurry_Example</string>
-			<key>productName</key>
-			<string>ViperMcFlurry</string>
-			<key>productReference</key>
-			<string>6003F58A195388D20070C39A</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>6003F58A195388D20070C39A</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ViperMcFlurry_Example.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>6003F58B195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6003F58A195388D20070C39A</string>
-				<string>6003F5AE195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F58C195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C732F1B789EA100226B47</string>
-				<string>6003F58D195388D20070C39A</string>
-				<string>6003F58F195388D20070C39A</string>
-				<string>6003F591195388D20070C39A</string>
-				<string>BCD36FC03A45A87A4597C0C7</string>
-				<string>8284984F2455D95519E1A3D9</string>
-				<string>3F6F5979FBF96E09EF139449</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F58D195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>6003F58E195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F58D195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F58F195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>6003F590195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F58F195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F591195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>6003F592195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F591195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F593195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>162C73141B789B6800226B47</string>
-				<string>9FFF3D531B68C4D100BDD3F2</string>
-				<string>6003F59C195388D20070C39A</string>
-				<string>6003F59D195388D20070C39A</string>
-				<string>873B8AEA1B1F5CCA007FD442</string>
-				<string>6003F5A8195388D20070C39A</string>
-				<string>6003F594195388D20070C39A</string>
-				<string>D24D49061BD4C9ED00C77475</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Example for ViperMcFlurry</string>
-			<key>path</key>
-			<string>ViperMcFlurry</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F594195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>169FC0D71B95C86E008547D7</string>
-				<string>169FC0D81B95C86E008547D7</string>
-				<string>6003F596195388D20070C39A</string>
-				<string>6003F599195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F596195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6003F597195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F597195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F598195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F596195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F599195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F59A195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F599195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F59C195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RamblerAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F59D195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RamblerAppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F59E195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F59D195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F5A8195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5A9195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F5A8195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F5AA195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F5AB195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6003F5B2195388D20070C39A</string>
-				<string>6003F5B1195388D20070C39A</string>
-				<string>2F8EC9FE21353262E6D3028E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F5AC195388D20070C39A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>6003F5BA195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>6003F5AD195388D20070C39A</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>6003F5C2195388D20070C39A</string>
-			<key>buildPhases</key>
-			<array>
-				<string>BFF50882DD753EC3B7C13E59</string>
-				<string>6003F5AA195388D20070C39A</string>
-				<string>6003F5AB195388D20070C39A</string>
-				<string>6003F5AC195388D20070C39A</string>
-				<string>5FB186E48B14A2189DA1EA83</string>
-				<string>138D895A56E50306869154A6</string>
-				<string>29A94EBD936C47E4D47A9A6C</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>6003F5B4195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>ViperMcFlurry_Tests</string>
-			<key>productName</key>
-			<string>ViperMcFlurryTests</string>
-			<key>productReference</key>
-			<string>6003F5AE195388D20070C39A</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>6003F5AE195388D20070C39A</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ViperMcFlurry_Tests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>6003F5B1195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F58D195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F5B2195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F591195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F5B3195388D20070C39A</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>6003F582195388D10070C39A</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>6003F589195388D20070C39A</string>
-			<key>remoteInfo</key>
-			<string>ViperMcFlurry</string>
-		</dict>
-		<key>6003F5B4195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>6003F589195388D20070C39A</string>
-			<key>targetProxy</key>
-			<string>6003F5B3195388D20070C39A</string>
-		</dict>
-		<key>6003F5B5195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6003F5B6195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5B6195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6003F5B7195388D20070C39A</string>
-				<string>6003F5B8195388D20070C39A</string>
-				<string>606FC2411953D9B200FFA9A0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5B7195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Tests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5B8195388D20070C39A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6003F5B9195388D20070C39A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5B9195388D20070C39A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6003F5BA195388D20070C39A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6003F5B8195388D20070C39A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6003F5BD195388D20070C39A</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>6003F5BE195388D20070C39A</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6003F5BF195388D20070C39A</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>6003F5C0195388D20070C39A</string>
-				<string>6003F5C1195388D20070C39A</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6003F5C0195388D20070C39A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3E218B7F42124CFBDB835247</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>ViperMcFlurry/ViperMcFlurry-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>ViperMcFlurry/ViperMcFlurry-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LIBRARY_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>MODULE_NAME</key>
-				<string>ExampleApp</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>$(inherited)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>6003F5C1195388D20070C39A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>29CC82345586C4F662E7C65C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>ViperMcFlurry/ViperMcFlurry-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>ViperMcFlurry/ViperMcFlurry-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LIBRARY_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>MODULE_NAME</key>
-				<string>ExampleApp</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>$(inherited)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6003F5C2195388D20070C39A</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>6003F5C3195388D20070C39A</string>
-				<string>6003F5C4195388D20070C39A</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>6003F5C3195388D20070C39A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>9DB79ED922F73E404786FD30</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(TEST_HOST)</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Tests/Tests-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>Tests/Tests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUILT_PRODUCTS_DIR)/ViperMcFlurry_Example.app/ViperMcFlurry_Example</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>6003F5C4195388D20070C39A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F7BF77682AD97D2B0DE14324</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(TEST_HOST)</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Tests/Tests-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Tests/Tests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUILT_PRODUCTS_DIR)/ViperMcFlurry_Example.app/ViperMcFlurry_Example</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>606FC2411953D9B200FFA9A0</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Tests-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>60FF7A9C1954A5C5007DD14C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>96F30E1F9FBD8F1AF02466B7</string>
-				<string>BFAB36AAE88EAE4784F1616E</string>
-				<string>29585292F60D04C0C6BFE358</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Podspec Metadata</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8284984F2455D95519E1A3D9</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Pods_ViperMcFlurry_Example.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>873B8AEA1B1F5CCA007FD442</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>path</key>
-			<string>Main.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>873B8AEB1B1F5CCA007FD442</key>
-		<dict>
-			<key>fileRef</key>
-			<string>873B8AEA1B1F5CCA007FD442</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>96F30E1F9FBD8F1AF02466B7</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>ViperMcFlurry.podspec</string>
-			<key>path</key>
-			<string>../ViperMcFlurry.podspec</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9DB79ED922F73E404786FD30</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ViperMcFlurry_Tests.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9E0EE8EC6CC5F15FDF605C15</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>9FFF3D531B68C4D100BDD3F2</key>
-		<dict>
-			<key>children</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Testing</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEB035DEF2B1E52B5823E72B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>BCD36FC03A45A87A4597C0C7</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>BFAB36AAE88EAE4784F1616E</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>net.daringfireball.markdown</string>
-			<key>name</key>
-			<string>README.md</string>
-			<key>path</key>
-			<string>../README.md</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BFF50882DD753EC3B7C13E59</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>C2C905018238A19115ED6AC6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8284984F2455D95519E1A3D9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C6050BAFABC07C78254F390F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>D24D49001BD1049400C77475</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleBetaModuleAssembly.h</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D24D49011BD1049400C77475</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleBetaModuleAssembly.m</string>
-			<key>path</key>
-			<string>Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D24D49021BD1049400C77475</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D24D49011BD1049400C77475</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D24D49031BD1049E00C77475</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaModuleAssembly.h</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D24D49041BD1049E00C77475</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RamblerModuleAlphaModuleAssembly.m</string>
-			<key>path</key>
-			<string>Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D24D49051BD1049E00C77475</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D24D49041BD1049E00C77475</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D24D49061BD4C9ED00C77475</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>path</key>
-			<string>LaunchScreen.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D24D49071BD4C9ED00C77475</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D24D49061BD4C9ED00C77475</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7BF77682AD97D2B0DE14324</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ViperMcFlurry_Tests.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>6003F582195388D10070C39A</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		162C73251B789D6700226B47 /* RamblerModuleAlphaInteractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C73171B789D6700226B47 /* RamblerModuleAlphaInteractor.m */; };
+		162C73271B789D6700226B47 /* RamblerModuleAlphaPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C731D1B789D6700226B47 /* RamblerModuleAlphaPresenter.m */; };
+		162C73281B789D6700226B47 /* RamblerModuleAlphaRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C731F1B789D6700226B47 /* RamblerModuleAlphaRouter.m */; };
+		162C73291B789D6700226B47 /* RamblerModuleAlphaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C73221B789D6700226B47 /* RamblerModuleAlphaViewController.m */; };
+		162C73401B78A45F00226B47 /* RamblerModuleBetaInteractor.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C73321B78A45F00226B47 /* RamblerModuleBetaInteractor.m */; };
+		162C73421B78A45F00226B47 /* RamblerModuleBetaPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C73381B78A45F00226B47 /* RamblerModuleBetaPresenter.m */; };
+		162C73431B78A45F00226B47 /* RamblerModuleBetaRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C733A1B78A45F00226B47 /* RamblerModuleBetaRouter.m */; };
+		162C73441B78A45F00226B47 /* RamblerModuleBetaViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 162C733D1B78A45F00226B47 /* RamblerModuleBetaViewController.m */; };
+		2F8EC9FE21353262E6D3028E /* Pods_ViperMcFlurry_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F6F5979FBF96E09EF139449 /* Pods_ViperMcFlurry_Tests.framework */; };
+		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
+		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
+		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
+		6003F598195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F596195388D20070C39A /* InfoPlist.strings */; };
+		6003F59A195388D20070C39A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F599195388D20070C39A /* main.m */; };
+		6003F59E195388D20070C39A /* RamblerAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F59D195388D20070C39A /* RamblerAppDelegate.m */; };
+		6003F5A9195388D20070C39A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5A8195388D20070C39A /* Images.xcassets */; };
+		6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
+		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
+		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
+		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
+		C2C905018238A19115ED6AC6 /* Pods_ViperMcFlurry_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8284984F2455D95519E1A3D9 /* Pods_ViperMcFlurry_Example.framework */; };
+		D24D49021BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = D24D49011BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m */; };
+		D24D49051BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m in Sources */ = {isa = PBXBuildFile; fileRef = D24D49041BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m */; };
+		D24D49071BD4C9ED00C77475 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D24D49061BD4C9ED00C77475 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6003F5B3195388D20070C39A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6003F582195388D10070C39A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6003F589195388D20070C39A;
+			remoteInfo = ViperMcFlurry;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		162C73161B789D6700226B47 /* RamblerModuleAlphaInteractor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaInteractor.h; path = Viper/ModuleAlpha/RamblerModuleAlphaInteractor.h; sourceTree = "<group>"; };
+		162C73171B789D6700226B47 /* RamblerModuleAlphaInteractor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleAlphaInteractor.m; path = Viper/ModuleAlpha/RamblerModuleAlphaInteractor.m; sourceTree = "<group>"; };
+		162C73181B789D6700226B47 /* RamblerModuleAlphaInteractorInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaInteractorInput.h; path = Viper/ModuleAlpha/RamblerModuleAlphaInteractorInput.h; sourceTree = "<group>"; };
+		162C73191B789D6700226B47 /* RamblerModuleAlphaInteractorOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaInteractorOutput.h; path = Viper/ModuleAlpha/RamblerModuleAlphaInteractorOutput.h; sourceTree = "<group>"; };
+		162C731C1B789D6700226B47 /* RamblerModuleAlphaPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaPresenter.h; path = Viper/ModuleAlpha/RamblerModuleAlphaPresenter.h; sourceTree = "<group>"; };
+		162C731D1B789D6700226B47 /* RamblerModuleAlphaPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleAlphaPresenter.m; path = Viper/ModuleAlpha/RamblerModuleAlphaPresenter.m; sourceTree = "<group>"; };
+		162C731E1B789D6700226B47 /* RamblerModuleAlphaRouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaRouter.h; path = Viper/ModuleAlpha/RamblerModuleAlphaRouter.h; sourceTree = "<group>"; };
+		162C731F1B789D6700226B47 /* RamblerModuleAlphaRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleAlphaRouter.m; path = Viper/ModuleAlpha/RamblerModuleAlphaRouter.m; sourceTree = "<group>"; };
+		162C73201B789D6700226B47 /* RamblerModuleAlphaRouterInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaRouterInput.h; path = Viper/ModuleAlpha/RamblerModuleAlphaRouterInput.h; sourceTree = "<group>"; };
+		162C73211B789D6700226B47 /* RamblerModuleAlphaViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaViewController.h; path = Viper/ModuleAlpha/RamblerModuleAlphaViewController.h; sourceTree = "<group>"; };
+		162C73221B789D6700226B47 /* RamblerModuleAlphaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleAlphaViewController.m; path = Viper/ModuleAlpha/RamblerModuleAlphaViewController.m; sourceTree = "<group>"; };
+		162C73231B789D6700226B47 /* RamblerModuleAlphaViewInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaViewInput.h; path = Viper/ModuleAlpha/RamblerModuleAlphaViewInput.h; sourceTree = "<group>"; };
+		162C73241B789D6700226B47 /* RamblerModuleAlphaViewOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaViewOutput.h; path = Viper/ModuleAlpha/RamblerModuleAlphaViewOutput.h; sourceTree = "<group>"; };
+		162C732F1B789EA100226B47 /* libPods-ViperMcFlurry_Example.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-ViperMcFlurry_Example.a"; path = "Pods/../build/Debug-iphoneos/libPods-ViperMcFlurry_Example.a"; sourceTree = "<group>"; };
+		162C73311B78A45F00226B47 /* RamblerModuleBetaInteractor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaInteractor.h; path = Viper/ModuleBeta/RamblerModuleBetaInteractor.h; sourceTree = "<group>"; };
+		162C73321B78A45F00226B47 /* RamblerModuleBetaInteractor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleBetaInteractor.m; path = Viper/ModuleBeta/RamblerModuleBetaInteractor.m; sourceTree = "<group>"; };
+		162C73331B78A45F00226B47 /* RamblerModuleBetaInteractorInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaInteractorInput.h; path = Viper/ModuleBeta/RamblerModuleBetaInteractorInput.h; sourceTree = "<group>"; };
+		162C73341B78A45F00226B47 /* RamblerModuleBetaInteractorOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaInteractorOutput.h; path = Viper/ModuleBeta/RamblerModuleBetaInteractorOutput.h; sourceTree = "<group>"; };
+		162C73371B78A45F00226B47 /* RamblerModuleBetaPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaPresenter.h; path = Viper/ModuleBeta/RamblerModuleBetaPresenter.h; sourceTree = "<group>"; };
+		162C73381B78A45F00226B47 /* RamblerModuleBetaPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleBetaPresenter.m; path = Viper/ModuleBeta/RamblerModuleBetaPresenter.m; sourceTree = "<group>"; };
+		162C73391B78A45F00226B47 /* RamblerModuleBetaRouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaRouter.h; path = Viper/ModuleBeta/RamblerModuleBetaRouter.h; sourceTree = "<group>"; };
+		162C733A1B78A45F00226B47 /* RamblerModuleBetaRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleBetaRouter.m; path = Viper/ModuleBeta/RamblerModuleBetaRouter.m; sourceTree = "<group>"; };
+		162C733B1B78A45F00226B47 /* RamblerModuleBetaRouterInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaRouterInput.h; path = Viper/ModuleBeta/RamblerModuleBetaRouterInput.h; sourceTree = "<group>"; };
+		162C733C1B78A45F00226B47 /* RamblerModuleBetaViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaViewController.h; path = Viper/ModuleBeta/RamblerModuleBetaViewController.h; sourceTree = "<group>"; };
+		162C733D1B78A45F00226B47 /* RamblerModuleBetaViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleBetaViewController.m; path = Viper/ModuleBeta/RamblerModuleBetaViewController.m; sourceTree = "<group>"; };
+		162C733E1B78A45F00226B47 /* RamblerModuleBetaViewInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaViewInput.h; path = Viper/ModuleBeta/RamblerModuleBetaViewInput.h; sourceTree = "<group>"; };
+		162C733F1B78A45F00226B47 /* RamblerModuleBetaViewOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaViewOutput.h; path = Viper/ModuleBeta/RamblerModuleBetaViewOutput.h; sourceTree = "<group>"; };
+		162C73491B78A4A500226B47 /* RamblerModuleBetaInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaInput.h; path = Viper/ModuleBeta/RamblerModuleBetaInput.h; sourceTree = "<group>"; };
+		169FC0D71B95C86E008547D7 /* ViperMcFlurry-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ViperMcFlurry-Info.plist"; sourceTree = "<group>"; };
+		169FC0D81B95C86E008547D7 /* ViperMcFlurry-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ViperMcFlurry-Prefix.pch"; sourceTree = "<group>"; };
+		29585292F60D04C0C6BFE358 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		29CC82345586C4F662E7C65C /* Pods-ViperMcFlurry_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.release.xcconfig"; sourceTree = "<group>"; };
+		3E218B7F42124CFBDB835247 /* Pods-ViperMcFlurry_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		3F6F5979FBF96E09EF139449 /* Pods_ViperMcFlurry_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ViperMcFlurry_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6003F58A195388D20070C39A /* ViperMcFlurry_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ViperMcFlurry_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		6003F597195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		6003F599195388D20070C39A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		6003F59C195388D20070C39A /* RamblerAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RamblerAppDelegate.h; sourceTree = "<group>"; };
+		6003F59D195388D20070C39A /* RamblerAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RamblerAppDelegate.m; sourceTree = "<group>"; };
+		6003F5A8195388D20070C39A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		6003F5AE195388D20070C39A /* ViperMcFlurry_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ViperMcFlurry_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
+		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
+		8284984F2455D95519E1A3D9 /* Pods_ViperMcFlurry_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ViperMcFlurry_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		96F30E1F9FBD8F1AF02466B7 /* ViperMcFlurry.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = ViperMcFlurry.podspec; path = ../ViperMcFlurry.podspec; sourceTree = "<group>"; };
+		9DB79ED922F73E404786FD30 /* Pods-ViperMcFlurry_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		BCD36FC03A45A87A4597C0C7 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BFAB36AAE88EAE4784F1616E /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		D24D49001BD1049400C77475 /* RamblerModuleBetaModuleAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleBetaModuleAssembly.h; path = Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.h; sourceTree = "<group>"; };
+		D24D49011BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleBetaModuleAssembly.m; path = Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.m; sourceTree = "<group>"; };
+		D24D49031BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RamblerModuleAlphaModuleAssembly.h; path = Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.h; sourceTree = "<group>"; };
+		D24D49041BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RamblerModuleAlphaModuleAssembly.m; path = Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.m; sourceTree = "<group>"; };
+		D24D49061BD4C9ED00C77475 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		F7BF77682AD97D2B0DE14324 /* Pods-ViperMcFlurry_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViperMcFlurry_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6003F587195388D20070C39A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
+				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
+				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
+				C2C905018238A19115ED6AC6 /* Pods_ViperMcFlurry_Example.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6003F5AB195388D20070C39A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
+				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
+				2F8EC9FE21353262E6D3028E /* Pods_ViperMcFlurry_Tests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		162C73141B789B6800226B47 /* Viper */ = {
+			isa = PBXGroup;
+			children = (
+				162C732A1B789D6F00226B47 /* ModuleBeta */,
+				162C73151B789D3200226B47 /* ModuleAlpha */,
+			);
+			name = Viper;
+			sourceTree = "<group>";
+		};
+		162C73151B789D3200226B47 /* ModuleAlpha */ = {
+			isa = PBXGroup;
+			children = (
+				D24D49031BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.h */,
+				D24D49041BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m */,
+				162C732B1B789D7900226B47 /* View */,
+				162C732E1B789D8B00226B47 /* Interactor */,
+				162C732D1B789D8400226B47 /* Presenter */,
+				162C732C1B789D7E00226B47 /* Router */,
+			);
+			name = ModuleAlpha;
+			sourceTree = "<group>";
+		};
+		162C732A1B789D6F00226B47 /* ModuleBeta */ = {
+			isa = PBXGroup;
+			children = (
+				D24D49001BD1049400C77475 /* RamblerModuleBetaModuleAssembly.h */,
+				D24D49011BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m */,
+				162C73451B78A46400226B47 /* View */,
+				162C73471B78A47E00226B47 /* Interactor */,
+				162C73461B78A47800226B47 /* Presenter */,
+				162C73481B78A48400226B47 /* Router */,
+			);
+			name = ModuleBeta;
+			sourceTree = "<group>";
+		};
+		162C732B1B789D7900226B47 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				162C73211B789D6700226B47 /* RamblerModuleAlphaViewController.h */,
+				162C73221B789D6700226B47 /* RamblerModuleAlphaViewController.m */,
+				162C73231B789D6700226B47 /* RamblerModuleAlphaViewInput.h */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		162C732C1B789D7E00226B47 /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				162C731E1B789D6700226B47 /* RamblerModuleAlphaRouter.h */,
+				162C731F1B789D6700226B47 /* RamblerModuleAlphaRouter.m */,
+				162C73201B789D6700226B47 /* RamblerModuleAlphaRouterInput.h */,
+			);
+			name = Router;
+			sourceTree = "<group>";
+		};
+		162C732D1B789D8400226B47 /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				162C73191B789D6700226B47 /* RamblerModuleAlphaInteractorOutput.h */,
+				162C73241B789D6700226B47 /* RamblerModuleAlphaViewOutput.h */,
+				162C731C1B789D6700226B47 /* RamblerModuleAlphaPresenter.h */,
+				162C731D1B789D6700226B47 /* RamblerModuleAlphaPresenter.m */,
+			);
+			name = Presenter;
+			sourceTree = "<group>";
+		};
+		162C732E1B789D8B00226B47 /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				162C73161B789D6700226B47 /* RamblerModuleAlphaInteractor.h */,
+				162C73171B789D6700226B47 /* RamblerModuleAlphaInteractor.m */,
+				162C73181B789D6700226B47 /* RamblerModuleAlphaInteractorInput.h */,
+			);
+			name = Interactor;
+			sourceTree = "<group>";
+		};
+		162C73451B78A46400226B47 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				162C733E1B78A45F00226B47 /* RamblerModuleBetaViewInput.h */,
+				162C733C1B78A45F00226B47 /* RamblerModuleBetaViewController.h */,
+				162C733D1B78A45F00226B47 /* RamblerModuleBetaViewController.m */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		162C73461B78A47800226B47 /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				162C73341B78A45F00226B47 /* RamblerModuleBetaInteractorOutput.h */,
+				162C73371B78A45F00226B47 /* RamblerModuleBetaPresenter.h */,
+				162C73381B78A45F00226B47 /* RamblerModuleBetaPresenter.m */,
+				162C733F1B78A45F00226B47 /* RamblerModuleBetaViewOutput.h */,
+				162C73491B78A4A500226B47 /* RamblerModuleBetaInput.h */,
+			);
+			name = Presenter;
+			sourceTree = "<group>";
+		};
+		162C73471B78A47E00226B47 /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				162C73311B78A45F00226B47 /* RamblerModuleBetaInteractor.h */,
+				162C73321B78A45F00226B47 /* RamblerModuleBetaInteractor.m */,
+				162C73331B78A45F00226B47 /* RamblerModuleBetaInteractorInput.h */,
+			);
+			name = Interactor;
+			sourceTree = "<group>";
+		};
+		162C73481B78A48400226B47 /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				162C73391B78A45F00226B47 /* RamblerModuleBetaRouter.h */,
+				162C733A1B78A45F00226B47 /* RamblerModuleBetaRouter.m */,
+				162C733B1B78A45F00226B47 /* RamblerModuleBetaRouterInput.h */,
+			);
+			name = Router;
+			sourceTree = "<group>";
+		};
+		4D62E5BDBFF12E6425C93A40 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3E218B7F42124CFBDB835247 /* Pods-ViperMcFlurry_Example.debug.xcconfig */,
+				29CC82345586C4F662E7C65C /* Pods-ViperMcFlurry_Example.release.xcconfig */,
+				9DB79ED922F73E404786FD30 /* Pods-ViperMcFlurry_Tests.debug.xcconfig */,
+				F7BF77682AD97D2B0DE14324 /* Pods-ViperMcFlurry_Tests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		6003F581195388D10070C39A = {
+			isa = PBXGroup;
+			children = (
+				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
+				6003F593195388D20070C39A /* Example for ViperMcFlurry */,
+				6003F5B5195388D20070C39A /* Tests */,
+				6003F58C195388D20070C39A /* Frameworks */,
+				6003F58B195388D20070C39A /* Products */,
+				4D62E5BDBFF12E6425C93A40 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		6003F58B195388D20070C39A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6003F58A195388D20070C39A /* ViperMcFlurry_Example.app */,
+				6003F5AE195388D20070C39A /* ViperMcFlurry_Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6003F58C195388D20070C39A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				162C732F1B789EA100226B47 /* libPods-ViperMcFlurry_Example.a */,
+				6003F58D195388D20070C39A /* Foundation.framework */,
+				6003F58F195388D20070C39A /* CoreGraphics.framework */,
+				6003F591195388D20070C39A /* UIKit.framework */,
+				BCD36FC03A45A87A4597C0C7 /* libPods.a */,
+				8284984F2455D95519E1A3D9 /* Pods_ViperMcFlurry_Example.framework */,
+				3F6F5979FBF96E09EF139449 /* Pods_ViperMcFlurry_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6003F593195388D20070C39A /* Example for ViperMcFlurry */ = {
+			isa = PBXGroup;
+			children = (
+				162C73141B789B6800226B47 /* Viper */,
+				9FFF3D531B68C4D100BDD3F2 /* Testing */,
+				6003F59C195388D20070C39A /* RamblerAppDelegate.h */,
+				6003F59D195388D20070C39A /* RamblerAppDelegate.m */,
+				873B8AEA1B1F5CCA007FD442 /* Main.storyboard */,
+				6003F5A8195388D20070C39A /* Images.xcassets */,
+				6003F594195388D20070C39A /* Supporting Files */,
+				D24D49061BD4C9ED00C77475 /* LaunchScreen.storyboard */,
+			);
+			name = "Example for ViperMcFlurry";
+			path = ViperMcFlurry;
+			sourceTree = "<group>";
+		};
+		6003F594195388D20070C39A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				169FC0D71B95C86E008547D7 /* ViperMcFlurry-Info.plist */,
+				169FC0D81B95C86E008547D7 /* ViperMcFlurry-Prefix.pch */,
+				6003F596195388D20070C39A /* InfoPlist.strings */,
+				6003F599195388D20070C39A /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		6003F5B5195388D20070C39A /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				6003F5B6195388D20070C39A /* Supporting Files */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		6003F5B6195388D20070C39A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				6003F5B7195388D20070C39A /* Tests-Info.plist */,
+				6003F5B8195388D20070C39A /* InfoPlist.strings */,
+				606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		60FF7A9C1954A5C5007DD14C /* Podspec Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				96F30E1F9FBD8F1AF02466B7 /* ViperMcFlurry.podspec */,
+				BFAB36AAE88EAE4784F1616E /* README.md */,
+				29585292F60D04C0C6BFE358 /* LICENSE */,
+			);
+			name = "Podspec Metadata";
+			sourceTree = "<group>";
+		};
+		9FFF3D531B68C4D100BDD3F2 /* Testing */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Testing;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6003F589195388D20070C39A /* ViperMcFlurry_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "ViperMcFlurry_Example" */;
+			buildPhases = (
+				AEB035DEF2B1E52B5823E72B /* [CP] Check Pods Manifest.lock */,
+				6003F586195388D20070C39A /* Sources */,
+				6003F587195388D20070C39A /* Frameworks */,
+				6003F588195388D20070C39A /* Resources */,
+				C6050BAFABC07C78254F390F /* [CP] Copy Pods Resources */,
+				01BC9CB6C6F4D26F423048A6 /* [CP] Embed Pods Frameworks */,
+				9E0EE8EC6CC5F15FDF605C15 /* Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ViperMcFlurry_Example;
+			productName = ViperMcFlurry;
+			productReference = 6003F58A195388D20070C39A /* ViperMcFlurry_Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6003F5AD195388D20070C39A /* ViperMcFlurry_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "ViperMcFlurry_Tests" */;
+			buildPhases = (
+				BFF50882DD753EC3B7C13E59 /* [CP] Check Pods Manifest.lock */,
+				6003F5AA195388D20070C39A /* Sources */,
+				6003F5AB195388D20070C39A /* Frameworks */,
+				6003F5AC195388D20070C39A /* Resources */,
+				5FB186E48B14A2189DA1EA83 /* [CP] Copy Pods Resources */,
+				138D895A56E50306869154A6 /* [CP] Embed Pods Frameworks */,
+				29A94EBD936C47E4D47A9A6C /* Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6003F5B4195388D20070C39A /* PBXTargetDependency */,
+			);
+			name = ViperMcFlurry_Tests;
+			productName = ViperMcFlurryTests;
+			productReference = 6003F5AE195388D20070C39A /* ViperMcFlurry_Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6003F582195388D10070C39A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = Rambler;
+				LastUpgradeCheck = 0510;
+				ORGANIZATIONNAME = "Egor Tolstoy";
+				TargetAttributes = {
+					6003F589195388D20070C39A = {
+						DevelopmentTeam = RU64C364MT;
+					};
+					6003F5AD195388D20070C39A = {
+						TestTargetID = 6003F589195388D20070C39A;
+					};
+				};
+			};
+			buildConfigurationList = 6003F585195388D10070C39A /* Build configuration list for PBXProject "ViperMcFlurry" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6003F581195388D10070C39A;
+			productRefGroup = 6003F58B195388D20070C39A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6003F589195388D20070C39A /* ViperMcFlurry_Example */,
+				6003F5AD195388D20070C39A /* ViperMcFlurry_Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6003F588195388D20070C39A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
+				D24D49071BD4C9ED00C77475 /* LaunchScreen.storyboard in Resources */,
+				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
+				6003F598195388D20070C39A /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6003F5AC195388D20070C39A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		01BC9CB6C6F4D26F423048A6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		138D895A56E50306869154A6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		29A94EBD936C47E4D47A9A6C /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5FB186E48B14A2189DA1EA83 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Tests/Pods-ViperMcFlurry_Tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9E0EE8EC6CC5F15FDF605C15 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AEB035DEF2B1E52B5823E72B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		BFF50882DD753EC3B7C13E59 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		C6050BAFABC07C78254F390F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ViperMcFlurry_Example/Pods-ViperMcFlurry_Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6003F586195388D20070C39A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				162C73421B78A45F00226B47 /* RamblerModuleBetaPresenter.m in Sources */,
+				162C73291B789D6700226B47 /* RamblerModuleAlphaViewController.m in Sources */,
+				162C73251B789D6700226B47 /* RamblerModuleAlphaInteractor.m in Sources */,
+				162C73271B789D6700226B47 /* RamblerModuleAlphaPresenter.m in Sources */,
+				D24D49051BD1049E00C77475 /* RamblerModuleAlphaModuleAssembly.m in Sources */,
+				162C73431B78A45F00226B47 /* RamblerModuleBetaRouter.m in Sources */,
+				162C73441B78A45F00226B47 /* RamblerModuleBetaViewController.m in Sources */,
+				6003F59E195388D20070C39A /* RamblerAppDelegate.m in Sources */,
+				162C73401B78A45F00226B47 /* RamblerModuleBetaInteractor.m in Sources */,
+				D24D49021BD1049400C77475 /* RamblerModuleBetaModuleAssembly.m in Sources */,
+				162C73281B789D6700226B47 /* RamblerModuleAlphaRouter.m in Sources */,
+				6003F59A195388D20070C39A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6003F5AA195388D20070C39A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6003F5B4195388D20070C39A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6003F589195388D20070C39A /* ViperMcFlurry_Example */;
+			targetProxy = 6003F5B3195388D20070C39A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		6003F596195388D20070C39A /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6003F597195388D20070C39A /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		6003F5B8195388D20070C39A /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6003F5B9195388D20070C39A /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		6003F5BD195388D20070C39A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6003F5BE195388D20070C39A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6003F5C0195388D20070C39A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3E218B7F42124CFBDB835247 /* Pods-ViperMcFlurry_Example.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEVELOPMENT_TEAM = RU64C364MT;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ViperMcFlurry/ViperMcFlurry-Prefix.pch";
+				INFOPLIST_FILE = "ViperMcFlurry/ViperMcFlurry-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MODULE_NAME = ExampleApp;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		6003F5C1195388D20070C39A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29CC82345586C4F662E7C65C /* Pods-ViperMcFlurry_Example.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEVELOPMENT_TEAM = RU64C364MT;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ViperMcFlurry/ViperMcFlurry-Prefix.pch";
+				INFOPLIST_FILE = "ViperMcFlurry/ViperMcFlurry-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MODULE_NAME = ExampleApp;
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		6003F5C3195388D20070C39A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9DB79ED922F73E404786FD30 /* Pods-ViperMcFlurry_Tests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ViperMcFlurry_Example.app/ViperMcFlurry_Example";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		6003F5C4195388D20070C39A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F7BF77682AD97D2B0DE14324 /* Pods-ViperMcFlurry_Tests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
+				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ViperMcFlurry_Example.app/ViperMcFlurry_Example";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6003F585195388D10070C39A /* Build configuration list for PBXProject "ViperMcFlurry" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6003F5BD195388D20070C39A /* Debug */,
+				6003F5BE195388D20070C39A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "ViperMcFlurry_Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6003F5C0195388D20070C39A /* Debug */,
+				6003F5C1195388D20070C39A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "ViperMcFlurry_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6003F5C3195388D20070C39A /* Debug */,
+				6003F5C4195388D20070C39A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6003F582195388D10070C39A /* Project object */;
+}

--- a/Example/ViperMcFlurry/Main.storyboard
+++ b/Example/ViperMcFlurry/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A282b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Xfk-px-I3u">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Xfk-px-I3u">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--ModuleAlpha-->
@@ -14,12 +18,11 @@
                         <viewControllerLayoutGuide type="bottom" id="Quc-n3-ghc"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="AD9-fP-BNz">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Some Example Text" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Vvs-pw-cO1">
-                                <rect key="frame" x="24" y="88" width="552" height="30"/>
-                                <animations/>
+                                <rect key="frame" x="24" y="88" width="327" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="hBM-ki-otA"/>
                                 </constraints>
@@ -27,46 +30,41 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G9g-Gu-nDv">
-                                <rect key="frame" x="173" y="126" width="255" height="30"/>
-                                <animations/>
+                                <rect key="frame" x="60.5" y="126" width="255" height="30"/>
                                 <state key="normal" title="Send Data To Beta Module Via Segue">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="didClickSendDataButton:" destination="iSd-mR-aP9" eventType="touchUpInside" id="hZC-x9-OvQ"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qth-Ou-73f">
-                                <rect key="frame" x="20" y="218" width="560" height="362"/>
+                                <rect key="frame" x="20" y="218" width="335" height="429"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Container is Empty" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26x-KN-ORF">
-                                        <rect key="frame" x="208" y="171" width="145" height="21"/>
-                                        <animations/>
+                                        <rect key="frame" x="95.5" y="204.5" width="145" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <animations/>
-                                <color key="backgroundColor" red="1" green="0.4823529412" blue="0.1176470588" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="0.4823529412" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="centerY" secondItem="26x-KN-ORF" secondAttribute="centerY" id="KPJ-c4-cZn"/>
                                     <constraint firstAttribute="centerX" secondItem="26x-KN-ORF" secondAttribute="centerX" id="oGU-QZ-89o"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="raS-6e-eOm">
-                                <rect key="frame" x="206" y="172" width="189" height="30"/>
-                                <animations/>
+                                <rect key="frame" x="88.5" y="172" width="198" height="30"/>
                                 <state key="normal" title="Instantiate Beta With Factory">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="didClickInstantiateBetaButton:" destination="iSd-mR-aP9" eventType="touchUpInside" id="8XC-EK-RA0"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Vvs-pw-cO1" secondAttribute="trailing" constant="24" id="0ya-qW-Foe"/>
                             <constraint firstItem="raS-6e-eOm" firstAttribute="top" secondItem="G9g-Gu-nDv" secondAttribute="bottom" constant="16" id="3e1-a0-Zar"/>
@@ -101,22 +99,20 @@
                         <viewControllerLayoutGuide type="bottom" id="BTK-ON-ndF"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="7qd-IH-pMz">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Something went wrong..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V1J-do-Gh2">
-                                <rect key="frame" x="24" y="184" width="552" height="21"/>
-                                <animations/>
+                                <rect key="frame" x="24" y="184" width="327" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="AAX-6r-kF3"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="V1J-do-Gh2" firstAttribute="leading" secondItem="7qd-IH-pMz" secondAttribute="leading" constant="24" id="bOH-ew-mfU"/>
                             <constraint firstAttribute="trailing" secondItem="V1J-do-Gh2" secondAttribute="trailing" constant="24" id="nEA-WS-XyQ"/>
@@ -138,7 +134,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="AMb-g8-K36">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="iSd-mR-aP9" kind="relationship" relationship="rootViewController" id="oSw-TU-VRf"/>
@@ -157,36 +152,33 @@
                         <viewControllerLayoutGuide type="bottom" id="SBX-XO-86f"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="eG2-9G-h0w">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Something went wrong..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xHS-mZ-yC7">
-                                <rect key="frame" x="24" y="290" width="552" height="21"/>
-                                <animations/>
+                                <rect key="frame" x="24" y="323" width="327" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="o8T-8k-cBi"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B0M-hO-6tr">
-                                <rect key="frame" x="252" y="319" width="96" height="34"/>
-                                <animations/>
+                                <rect key="frame" x="139.5" y="352" width="96" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="96" id="acN-Xz-BfP"/>
                                 </constraints>
                                 <state key="normal" title="Remove">
-                                    <color key="titleColor" red="0.57636600732803345" green="0.56721252202987671" blue="0.64175301790237427" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="0.50389623641967773" green="0.49144250154495239" blue="0.57489657402038574" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="didClickRemoveModuleButton:" destination="ckW-Gb-QwD" eventType="touchUpInside" id="Rfg-sW-IIr"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" red="0.66845601797103882" green="0.77302712202072144" blue="0.94829195737838745" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.60735607147216797" green="0.71810704469680786" blue="0.93440687656402588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="xHS-mZ-yC7" firstAttribute="leading" secondItem="eG2-9G-h0w" secondAttribute="leading" constant="24" id="534-La-ipF"/>
                             <constraint firstAttribute="trailing" secondItem="xHS-mZ-yC7" secondAttribute="trailing" constant="24" id="9dO-Fb-EPd"/>
@@ -212,29 +204,26 @@
         <!--Rambler Module Beta View Controller-->
         <scene sceneID="KCC-4Y-LAS">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="0Th-vv-Ymd" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <viewController storyboardIdentifier="RamblerModuleBetaViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Lil-9P-Pbd" customClass="RamblerModuleBetaViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bgE-Wf-Gc0"/>
                         <viewControllerLayoutGuide type="bottom" id="Pog-W6-ean"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="7K4-ZM-kMA">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Something went wrong..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ta-1P-9ac">
-                                <rect key="frame" x="24" y="290" width="552" height="21"/>
-                                <animations/>
+                                <rect key="frame" x="24" y="323" width="327" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="bOa-Uv-2hG"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" red="0.6639818549156189" green="0.94611662626266479" blue="0.69968819618225098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.61060279607772827" green="0.94679057598114014" blue="0.64023005962371826" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="9ta-1P-9ac" firstAttribute="top" secondItem="bgE-Wf-Gc0" secondAttribute="bottom" constant="120" id="9nR-cy-yCW"/>
                             <constraint firstAttribute="trailing" secondItem="9ta-1P-9ac" secondAttribute="trailing" constant="24" id="Po4-sD-b02"/>
@@ -251,6 +240,7 @@
                         <outlet property="exampleStringLabel" destination="9ta-1P-9ac" id="kbF-DS-taR"/>
                     </connections>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0Th-vv-Ymd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2089" y="979"/>
         </scene>

--- a/Example/ViperMcFlurry/Main.storyboard
+++ b/Example/ViperMcFlurry/Main.storyboard
@@ -39,10 +39,10 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qth-Ou-73f">
-                                <rect key="frame" x="20" y="218" width="335" height="429"/>
+                                <rect key="frame" x="20" y="264" width="335" height="383"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Container is Empty" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="26x-KN-ORF">
-                                        <rect key="frame" x="95.5" y="204.5" width="145" height="21"/>
+                                        <rect key="frame" x="95.5" y="181.5" width="145" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -55,24 +55,35 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="raS-6e-eOm">
-                                <rect key="frame" x="88.5" y="172" width="198" height="30"/>
-                                <state key="normal" title="Instantiate Beta With Factory">
+                                <rect key="frame" x="32.5" y="172" width="310" height="30"/>
+                                <state key="normal" title="Instantiate Beta With Factory And Storyboard">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="didClickInstantiateBetaButton:" destination="iSd-mR-aP9" eventType="touchUpInside" id="8XC-EK-RA0"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXQ-8k-UI5">
+                                <rect key="frame" x="46" y="218" width="284" height="30"/>
+                                <state key="normal" title="Instantiate Gamman With Factory and Xib">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="didClickInstantiateGammaButton:" destination="iSd-mR-aP9" eventType="touchUpInside" id="jLY-Ro-8db"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="Qth-Ou-73f" firstAttribute="top" secondItem="ZXQ-8k-UI5" secondAttribute="bottom" constant="16" id="0Zl-EC-iIQ"/>
                             <constraint firstAttribute="trailing" secondItem="Vvs-pw-cO1" secondAttribute="trailing" constant="24" id="0ya-qW-Foe"/>
                             <constraint firstItem="raS-6e-eOm" firstAttribute="top" secondItem="G9g-Gu-nDv" secondAttribute="bottom" constant="16" id="3e1-a0-Zar"/>
                             <constraint firstItem="G9g-Gu-nDv" firstAttribute="centerX" secondItem="Vvs-pw-cO1" secondAttribute="centerX" id="3tU-ex-mji"/>
                             <constraint firstAttribute="trailing" secondItem="Qth-Ou-73f" secondAttribute="trailing" constant="20" id="43V-V9-IRx"/>
                             <constraint firstItem="Vvs-pw-cO1" firstAttribute="top" secondItem="3eo-31-7cb" secondAttribute="bottom" constant="24" id="8D7-eS-y3a"/>
-                            <constraint firstItem="Qth-Ou-73f" firstAttribute="top" secondItem="raS-6e-eOm" secondAttribute="bottom" constant="16" id="R6p-Y7-pAP"/>
                             <constraint firstItem="G9g-Gu-nDv" firstAttribute="top" secondItem="Vvs-pw-cO1" secondAttribute="bottom" constant="8" id="WTM-cv-J4t"/>
+                            <constraint firstItem="ZXQ-8k-UI5" firstAttribute="centerX" secondItem="AD9-fP-BNz" secondAttribute="centerX" id="WlM-o9-2E9"/>
+                            <constraint firstItem="ZXQ-8k-UI5" firstAttribute="top" secondItem="raS-6e-eOm" secondAttribute="bottom" constant="16" id="YQ4-Dc-fik"/>
                             <constraint firstAttribute="centerX" secondItem="raS-6e-eOm" secondAttribute="centerX" id="ktC-R5-tQW"/>
                             <constraint firstItem="Vvs-pw-cO1" firstAttribute="leading" secondItem="AD9-fP-BNz" secondAttribute="leading" constant="24" id="kwb-Tb-wxe"/>
                             <constraint firstItem="Quc-n3-ghc" firstAttribute="top" secondItem="Qth-Ou-73f" secondAttribute="bottom" constant="20" id="tMH-ED-TNg"/>

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.m
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaModuleAssembly.m
@@ -8,6 +8,7 @@
 #import "RamblerModuleAlphaModuleAssembly.h"
 
 #import "RamblerModuleBetaModuleAssembly.h"
+#import "RamblerModuleGammaModuleAssembly.h"
 
 #import "RamblerModuleAlphaViewController.h"
 #import "RamblerModuleAlphaInteractor.h"
@@ -17,6 +18,7 @@
 @interface  RamblerModuleAlphaModuleAssembly()
 
 @property (nonatomic,strong,readonly) RamblerModuleBetaModuleAssembly *betaModuleAssembly;
+@property (nonatomic,strong,readonly) RamblerModuleGammaModuleAssembly *gammaModuleAssembly;
 
 @end
 
@@ -62,6 +64,9 @@
                               
                               [definition injectProperty:@selector(betaModuleFactory)
                                                     with:[self.betaModuleAssembly factoryBetaModule]];
+                              
+                              [definition injectProperty:@selector(gammaModuleFactory)
+                                                    with:[self.gammaModuleAssembly factoryGammaModule]];
                           }];
 }
 

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaPresenter.m
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaPresenter.m
@@ -39,6 +39,14 @@
     }];
 }
 
+- (void)instantiateGammaButtonClicked {
+    __weak typeof(self) wself = self;
+    [self.view getDataWithResultBlock:^(NSString *data) {
+        typeof (self) sself = wself;
+        [sself.router instantiateGammaModuleWithExampleString:data];
+    }];
+}
+
 #pragma mark - RamblerModuleAlphaInteractorOutput
 
 @end

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouter.h
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouter.h
@@ -13,5 +13,6 @@
 
 @property (nonatomic,weak) id<RamblerViperModuleTransitionHandlerProtocol> transitionHandler;
 @property (nonatomic,strong) id<RamblerViperModuleFactoryProtocol> betaModuleFactory;
+@property (nonatomic,strong) id<RamblerViperModuleFactoryProtocol> gammaModuleFactory;
 
 @end

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouter.m
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouter.m
@@ -7,6 +7,7 @@
 
 #import "RamblerModuleAlphaRouter.h"
 #import "RamblerModuleBetaInput.h"
+#import "RamblerModuleGammaInput.h"
 
 static NSString* const RamblerAlphaToBetaSegue = @"RamblerAlphaToBetaSegue";
 
@@ -42,6 +43,23 @@ static NSString* const RamblerAlphaToBetaSegue = @"RamblerAlphaToBetaSegue";
                                    [moduleInput configureWithExampleString:exampleString];
                                    return nil;
                                }];
+}
+
+- (void)instantiateGammaModuleWithExampleString:(NSString*)exampleString {
+    [[self.transitionHandler openModuleUsingFactory:self.gammaModuleFactory
+                                withTransitionBlock:^(id <RamblerViperModuleTransitionHandlerProtocol> sourceModuleTransitionHandler,
+                                                      id <RamblerViperModuleTransitionHandlerProtocol> destinationModuleTransitionHandler) {
+                                    
+                                    UIViewController *sourceViewController = (id) sourceModuleTransitionHandler;
+                                    UIViewController *destinationViewController = (id) destinationModuleTransitionHandler;
+                                    
+                                    [sourceViewController.navigationController pushViewController:destinationViewController
+                                                                                         animated:YES];
+                                    
+                                }] thenChainUsingBlock:^id<RamblerViperModuleOutput>(id<RamblerModuleGammaInput> moduleInput) {
+                                    [moduleInput configureWithExampleString:exampleString];
+                                    return nil;
+                                }];
 }
 
 @end

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouterInput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaRouterInput.h
@@ -11,6 +11,7 @@
 
 - (void)openBetaModuleWithExampleString:(NSString*)exampleString;
 - (void)instantiateBetaModuleWithExampleString:(NSString*)exampleString;
+- (void)instantiateGammaModuleWithExampleString:(NSString*)exampleString;
 
 @end
 

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewController.h
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewController.h
@@ -18,6 +18,7 @@
 @property (nonatomic, weak) IBOutlet UITextField *textField;
 - (IBAction)didClickSendDataButton:(id)sender;
 - (IBAction)didClickInstantiateBetaButton:(id)sender;
+- (IBAction)didClickInstantiateGammaButton:(id)sender;
 
 @property (nonatomic, weak) IBOutlet UIView *moduleContainerView;
 

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewController.m
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewController.m
@@ -29,6 +29,11 @@
     [self.output instantiateBetaButtonClicked];
 }
 
+- (IBAction)didClickInstantiateGammaButton:(id)sender {
+    [self.textField resignFirstResponder];
+    [self.output instantiateGammaButtonClicked];
+}
+
 #pragma mark - RamblerModuleAlphaViewInput
 
 - (void)getDataWithResultBlock:(AlphaModuleViewDataResulBlock)resultBlock {

--- a/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewOutput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleAlpha/RamblerModuleAlphaViewOutput.h
@@ -12,6 +12,7 @@
 - (void)setupView;
 - (void)sendDataButtonClicked;
 - (void)instantiateBetaButtonClicked;
+- (void)instantiateGammaButtonClicked;
 
 @end
 

--- a/Example/ViperMcFlurry/Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.m
+++ b/Example/ViperMcFlurry/Viper/ModuleBeta/RamblerModuleBetaModuleAssembly.m
@@ -24,7 +24,7 @@
 - (id<RamblerViperModuleFactoryProtocol>)factoryBetaModule {
     return [TyphoonDefinition withClass:[RamblerViperModuleFactory class]
                           configuration:^(TyphoonDefinition *definition) {
-                              [definition useInitializer:@selector(initWithStoryboard:andRestorationId:)
+                              [definition useInitializer:@selector(initWithViewControllerLoader:andViewControllerIdentifier:)
                                               parameters:^(TyphoonMethod *initializer) {
                                                   [initializer injectParameterWith:[self storyboardBetaModule]];
                                                   [initializer injectParameterWith:@"RamblerModuleBetaViewController"];

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInput.h
@@ -1,0 +1,15 @@
+//
+//  RamblerModuleGammaInput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <ViperMcFlurry/ViperMcFlurry.h>
+
+@protocol RamblerModuleGammaInput <RamblerViperModuleInput>
+
+- (void)configureWithExampleString:(NSString*)exampleString;
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractor.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractor.h
@@ -1,0 +1,18 @@
+//
+//  RamblerModuleGammaInteractor.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RamblerModuleGammaInteractorInput.h"
+
+@protocol RamblerModuleGammaInteractorOutput;
+
+@interface RamblerModuleGammaInteractor : NSObject <RamblerModuleGammaInteractorInput>
+
+@property (nonatomic, weak) id<RamblerModuleGammaInteractorOutput> output;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractor.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractor.m
@@ -1,0 +1,19 @@
+//
+//  RamblerModuleGammaInteractor.m
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import "RamblerModuleGammaInteractor.h"
+#import "RamblerModuleGammaInteractorOutput.h"
+
+@interface RamblerModuleGammaInteractor()
+
+@end
+
+@implementation RamblerModuleGammaInteractor
+
+#pragma mark - RamblerModuleGammaInteractorInput
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractorInput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractorInput.h
@@ -1,0 +1,13 @@
+//
+//  RamblerModuleGammaInteractorInput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol RamblerModuleGammaInteractorInput <NSObject>
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractorOutput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaInteractorOutput.h
@@ -1,0 +1,13 @@
+//
+//  RamblerModuleGammaInteractorOutput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol RamblerModuleGammaInteractorOutput <NSObject>
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.h
@@ -1,0 +1,17 @@
+//
+//  RamblerModuleGammaModuleAssembly.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Typhoon/Typhoon.h>
+
+@protocol RamblerViperModuleFactoryProtocol;
+
+@interface RamblerModuleGammaModuleAssembly : TyphoonAssembly
+
+- (id<RamblerViperModuleFactoryProtocol>)factoryGammaModule;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.m
@@ -1,0 +1,85 @@
+//
+//  RamblerModuleGammaModuleAssembly.m
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import "RamblerModuleGammaModuleAssembly.h"
+
+#import <ViperMcFlurry/ViperMcFlurry.h>
+
+#import "RamblerModuleGammaViewController.h"
+#import "RamblerModuleGammaInteractor.h"
+#import "RamblerModuleGammaPresenter.h"
+#import "RamblerModuleGammaRouter.h"
+
+
+@interface  RamblerModuleGammaModuleAssembly()
+
+@end
+
+@implementation  RamblerModuleGammaModuleAssembly
+
+- (id<RamblerViperModuleFactoryProtocol>)factoryGammaModule {
+    return [TyphoonDefinition withClass:[RamblerViperModuleFactory class]
+                          configuration:^(TyphoonDefinition *definition) {
+                              [definition useInitializer:@selector(initWithStoryboard:andRestorationId:)
+                                              parameters:^(TyphoonMethod *initializer) {
+                                                  [initializer injectParameterWith:[self storyboardGammaModule]];
+                                                  [initializer injectParameterWith:@"RamblerModuleGammaViewController"];
+                                              }];
+                          }];
+}
+
+- (UIStoryboard*)storyboardGammaModule {
+    return [TyphoonDefinition withClass:[TyphoonStoryboard class]
+                          configuration:^(TyphoonDefinition *definition) {
+                              [definition useInitializer:@selector(storyboardWithName:factory:bundle:)
+                                              parameters:^(TyphoonMethod *initializer) {
+                                                  [initializer injectParameterWith:@"Main"];
+                                                  [initializer injectParameterWith:self];
+                                                  [initializer injectParameterWith:nil];
+                                              }];
+                          }];
+}
+
+- (RamblerModuleGammaViewController *)viewRamblerModuleGamma {
+
+    return [TyphoonDefinition withClass:[RamblerModuleGammaViewController class]
+                          configuration:^(TyphoonDefinition *definition) {
+                            [definition injectProperty:@selector(output) 
+                                                  with:[self presenterRamblerModuleGamma]];
+             }];
+}
+
+- (RamblerModuleGammaInteractor *)interactorRamblerModuleGamma {
+
+    return [TyphoonDefinition withClass:[RamblerModuleGammaInteractor class]
+                          configuration:^(TyphoonDefinition *definition) {
+                            [definition injectProperty:@selector(output) 
+                                                  with:[self presenterRamblerModuleGamma]];
+             }];
+}
+
+- (RamblerModuleGammaPresenter *)presenterRamblerModuleGamma {
+
+    return [TyphoonDefinition withClass:[RamblerModuleGammaPresenter class]
+                          configuration:^(TyphoonDefinition *definition) {
+                            [definition injectProperty:@selector(view) 
+                                                  with:[self viewRamblerModuleGamma]];                                            
+                            [definition injectProperty:@selector(interactor) 
+                                                  with:[self interactorRamblerModuleGamma]];
+                            [definition injectProperty:@selector(router) 
+                                                  with:[self routerRamblerModuleGamma]];
+            }];
+}
+
+- (RamblerModuleGammaRouter *)routerRamblerModuleGamma {
+    return [TyphoonDefinition withClass:[RamblerModuleGammaRouter class] configuration:^(TyphoonDefinition *definition) {
+        [definition injectProperty:@selector(transitionHandler)
+                              with:[self viewRamblerModuleGamma]];
+    }];
+}
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaModuleAssembly.m
@@ -24,20 +24,19 @@
 - (id<RamblerViperModuleFactoryProtocol>)factoryGammaModule {
     return [TyphoonDefinition withClass:[RamblerViperModuleFactory class]
                           configuration:^(TyphoonDefinition *definition) {
-                              [definition useInitializer:@selector(initWithStoryboard:andRestorationId:)
+                              [definition useInitializer:@selector(initWithViewControllerLoader:andViewControllerIdentifier:)
                                               parameters:^(TyphoonMethod *initializer) {
-                                                  [initializer injectParameterWith:[self storyboardGammaModule]];
+                                                  [initializer injectParameterWith:[self nibLoaderGammaModule]];
                                                   [initializer injectParameterWith:@"RamblerModuleGammaViewController"];
                                               }];
                           }];
 }
 
-- (UIStoryboard*)storyboardGammaModule {
-    return [TyphoonDefinition withClass:[TyphoonStoryboard class]
+- (id)nibLoaderGammaModule {
+    return [TyphoonDefinition withClass:[TyphoonNibLoader class]
                           configuration:^(TyphoonDefinition *definition) {
-                              [definition useInitializer:@selector(storyboardWithName:factory:bundle:)
+                              [definition useInitializer:@selector(nibLoaderWithFactory:bundle:)
                                               parameters:^(TyphoonMethod *initializer) {
-                                                  [initializer injectParameterWith:@"Main"];
                                                   [initializer injectParameterWith:self];
                                                   [initializer injectParameterWith:nil];
                                               }];

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaPresenter.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaPresenter.h
@@ -1,0 +1,24 @@
+//
+//  RamblerModuleGammaPresenter.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RamblerModuleGammaViewOutput.h"
+#import "RamblerModuleGammaInteractorOutput.h"
+#import "RamblerModuleGammaInput.h"
+
+@protocol RamblerModuleGammaViewInput;
+@protocol RamblerModuleGammaInteractorInput;
+@protocol RamblerModuleGammaRouterInput;
+
+@interface RamblerModuleGammaPresenter : NSObject <RamblerModuleGammaViewOutput, RamblerModuleGammaInteractorOutput, RamblerModuleGammaInput>
+
+@property (nonatomic, weak) id<RamblerModuleGammaViewInput> view;
+@property (nonatomic, strong) id<RamblerModuleGammaInteractorInput> interactor;
+@property (nonatomic, strong) id<RamblerModuleGammaRouterInput> router;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaPresenter.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaPresenter.m
@@ -1,0 +1,35 @@
+//
+//  RamblerModuleGammaPresenter.m
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import "RamblerModuleGammaPresenter.h"
+#import "RamblerModuleGammaViewInput.h"
+#import "RamblerModuleGammaInteractorInput.h"
+#import "RamblerModuleGammaRouterInput.h"
+
+@interface RamblerModuleGammaPresenter()
+
+@property (nonatomic,strong) NSString* exampleString;
+
+@end
+
+@implementation RamblerModuleGammaPresenter
+
+#pragma mark - RamblerModuleGammaInput
+
+- (void)configureWithExampleString:(NSString*)exampleString {
+    self.exampleString = exampleString;
+}
+
+#pragma mark - RamblerModuleGammaViewOutput
+
+- (void)setupView {
+    [self.view setExampleString:self.exampleString];
+}
+
+#pragma mark - RamblerModuleGammaInteractorOutput
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouter.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouter.h
@@ -1,0 +1,16 @@
+//
+//  RamblerModuleGammaRouter.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <ViperMcFlurry/ViperMcFlurry.h>
+#import "RamblerModuleGammaRouterInput.h"
+
+@interface RamblerModuleGammaRouter : NSObject <RamblerModuleGammaRouterInput>
+
+@property (nonatomic,weak) id<RamblerViperModuleTransitionHandlerProtocol> transitionHandler;
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouter.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouter.m
@@ -1,0 +1,18 @@
+//
+//  RamblerModuleGammaRouter.m
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import "RamblerModuleGammaRouter.h"
+
+@implementation RamblerModuleGammaRouter
+
+#pragma mark - RamblerModuleGammaRouterInput
+
+- (void)removeModule {
+    [self.transitionHandler closeCurrentModule:NO];
+}
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouterInput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaRouterInput.h
@@ -1,0 +1,15 @@
+//
+//  RamblerModuleGammaRouterInput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol RamblerModuleGammaRouterInput <NSObject>
+
+- (void)removeModule;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.h
@@ -1,0 +1,23 @@
+//
+//  RamblerModuleGammaViewController.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "RamblerModuleGammaViewInput.h"
+#import <ViperMcFlurry/ViperMcFlurry.h>
+
+@protocol RamblerViperModuleConfiguratorProtocol;
+@protocol RamblerModuleGammaViewOutput;
+
+@interface RamblerModuleGammaViewController : UIViewController <RamblerModuleGammaViewInput,RamblerViperModuleTransitionHandlerProtocol>
+
+@property (nonatomic, strong) id<RamblerModuleGammaViewOutput> output;
+@property (nonatomic, weak)   id<RamblerViperModuleConfiguratorProtocol> moduleConfigurator;
+
+@property (nonatomic, strong) IBOutlet UILabel *exampleStringLabel;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.m
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.m
@@ -1,0 +1,27 @@
+//
+//  RamblerModuleGammaViewController.m
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import "RamblerModuleGammaViewController.h"
+#import "RamblerModuleGammaViewOutput.h"
+#import <ViperMcFlurry/ViperMcFlurry.h>
+
+@interface RamblerModuleGammaViewController()
+
+@end
+
+@implementation RamblerModuleGammaViewController
+
+- (void)viewDidLoad {
+	[super viewDidLoad];
+	[self.output setupView];
+}
+
+- (void)setExampleString:(NSString *)exampleString {
+    self.exampleStringLabel.text = exampleString;
+}
+
+@end

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.xib
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewController.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RamblerModuleGammaViewController">
+            <connections>
+                <outlet property="exampleStringLabel" destination="9Ha-YV-tNB" id="ixi-Ww-Mbv"/>
+                <outlet property="view" destination="IC6-6q-aIP" id="AlT-SK-MQE"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="IC6-6q-aIP">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Something went wrong..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ha-YV-tNB">
+                    <rect key="frame" x="24" y="323" width="327" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="21" id="WEx-9Q-7ld"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="0.94368707135833341" green="0.158203125" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="9Ha-YV-tNB" secondAttribute="trailing" constant="24" id="O2z-6e-Vch"/>
+                <constraint firstAttribute="centerY" secondItem="9Ha-YV-tNB" secondAttribute="centerY" id="rxO-hE-ft0"/>
+                <constraint firstItem="9Ha-YV-tNB" firstAttribute="leading" secondItem="IC6-6q-aIP" secondAttribute="leading" constant="24" id="uqC-GO-QUZ"/>
+            </constraints>
+        </view>
+    </objects>
+</document>

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewInput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewInput.h
@@ -1,0 +1,18 @@
+//
+//  RamblerModuleGammaViewInput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ 
+ */
+@protocol RamblerModuleGammaViewInput <NSObject>
+
+- (void)setExampleString:(NSString*)exampleString;
+
+@end
+

--- a/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewOutput.h
+++ b/Example/ViperMcFlurry/Viper/ModuleGamma/RamblerModuleGammaViewOutput.h
@@ -1,0 +1,15 @@
+//
+//  RamblerModuleGammaViewOutput.h
+//  ViperMcFlurry
+//
+//  Copyright (c) 2017 Rambler DS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol RamblerModuleGammaViewOutput <NSObject>
+
+- (void)setupView;
+
+@end
+

--- a/Example/ViperMcFlurry/ViperMcFlurry-Info.plist
+++ b/Example/ViperMcFlurry/ViperMcFlurry-Info.plist
@@ -26,6 +26,7 @@
 	<true/>
 	<key>TyphoonInitialAssemblies</key>
 	<array>
+		<string>RamblerModuleGammaModuleAssembly</string>
 		<string>RamblerModuleBetaModuleAssembly</string>
 		<string>RamblerModuleAlphaModuleAssembly</string>
 	</array>

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@
 Module factory can be replaced with segues for most cases. Except you need to create complex module or nontrivial module instantiation logic.
 
 - Use ```RamblerViperModuleFactory``` object as module fabric with Typhoon.
-- Set definition Initializer to ```initWithStoryboard:andRestorationId:```
-    - First parameter is UIStoryboard instance,
-    - Second parameter is RestorationID of ViewController.
+- Set definition Initializer to ```initWithViewControllerLoader:andViewControllerIdentifier:```
+    - First parameter is the object which loads the view controller, e.g. UIStoryboard or TyphoonNibLoader instance,
+    - Second parameter is view controller's identifier, e.g. RestorationID or NibName of ViewController.
 - Typhoon will initialize module from ViewController.
 - Inject this Factory into router.
 - Call Transition Handler's method ``- openModuleUsingFactory:withTransitionBlock:``.

--- a/Source/RamblerViperModuleFactory.h
+++ b/Source/RamblerViperModuleFactory.h
@@ -13,10 +13,19 @@
  */
 @interface RamblerViperModuleFactory : NSObject<RamblerViperModuleFactoryProtocol>
 
-- (instancetype)initWithStoryboard:(UIStoryboard*)storyboard andRestorationId:(NSString*)restorationId;
+/**
+ @param loader The object which loads the view controller, loader should respond to instantiateViewControllerWithIdentifier:. E.g. UIStoryboard or TyphoonNibLoader.
+ @param identifier The view controller's identifier. E.g. storyboard ID for UIStoryboard or nib name for TyphoonNibLoader.
+ */
+- (instancetype)initWithViewControllerLoader:(id)loader andViewControllerIdentifier:(NSString*)identifier;
+
+- (instancetype)initWithStoryboard:(UIStoryboard*)storyboard andRestorationId:(NSString*)restorationId __attribute__((deprecated("use initWithViewControllerKeeper:andViewControllerIdentifier: instead.")));
 - (instancetype)initWithViewHandler:(id<RamblerViperModuleTransitionHandlerProtocol>(^)(void))viewHandler;
 
-@property (nonatomic,strong,readonly) UIStoryboard *storyboard;
-@property (nonatomic,strong,readonly) NSString* restorationId;
+@property (nonatomic,strong,readonly) UIStoryboard *storyboard __attribute__((deprecated("use viewControllerLoader instead.")));
+@property (nonatomic,strong,readonly) NSString* restorationId __attribute__((deprecated("use viewControllerIdentifier instead.")));
+
+@property (nonatomic,strong,readonly) id viewControllerLoader;
+@property (nonatomic,strong,readonly) NSString* viewControllerIdentifier;
 
 @end

--- a/Source/RamblerViperModuleFactory.m
+++ b/Source/RamblerViperModuleFactory.m
@@ -12,17 +12,29 @@
 
 @property (nonatomic,strong) UIStoryboard *storyboard;
 @property (nonatomic,strong) NSString* restorationId;
+
+@property (nonatomic,strong) id viewControllerLoader;
+@property (nonatomic,strong) NSString* viewControllerIdentifier;
 @property (nonatomic,copy) id<RamblerViperModuleTransitionHandlerProtocol>(^viewHandler)(void);
 
 @end
 
 @implementation RamblerViperModuleFactory
 
+- (instancetype)initWithViewControllerLoader:(id)loader andViewControllerIdentifier:(NSString*)identifier {
+    self = [super init];
+    if (self) {
+        self.viewControllerLoader = loader;
+        self.viewControllerIdentifier = identifier;
+    }
+    return self;
+}
+
 - (instancetype)initWithStoryboard:(UIStoryboard*)storyboard andRestorationId:(NSString*)restorationId {
     self = [super init];
     if (self) {
-        self.storyboard = storyboard;
-        self.restorationId = restorationId;
+        self.viewControllerLoader = storyboard;
+        self.viewControllerIdentifier = restorationId;
     }
     return self;
 }
@@ -42,8 +54,20 @@
         return self.viewHandler();
     }
     
-    id<RamblerViperModuleTransitionHandlerProtocol> destinationViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.restorationId];
+    NSAssert([self.viewControllerLoader respondsToSelector:@selector(instantiateViewControllerWithIdentifier:)], @"RamblerViperModuleFactory's view controller loader should respond to instantiateViewControllerWithIdentifier:");
+    
+    id<RamblerViperModuleTransitionHandlerProtocol> destinationViewController = [self.viewControllerLoader instantiateViewControllerWithIdentifier:self.viewControllerIdentifier];
     return destinationViewController;
+}
+
+#pragma mark - Getters
+
+- (UIStoryboard *)storyboard {
+    return self.viewControllerLoader;
+}
+
+- (NSString *)restorationId {
+    return self.viewControllerIdentifier;
 }
 
 @end


### PR DESCRIPTION
Recently my pull request to Typhoon was accepted and new version was released.

It contains TyphoonNibLoader, which works like TyphoonStoryboard and loads view controllers from xibs.

It is time to add ability to use TyphoonNibLoader to RamblerViperModuleFactory, which currently takes only UIStoryboard.


I created GammaModule, which demonstrates work of RamblerViperModuleFactory with usage of TyphoonNibLoader.

RamblerViperModuleFactory has new initializer which now takes any object, which responds to instantiateViewControllerWithIdentifier: and identifier, which can be a restorationId in case of using UIStoryboard or a nibName in case of using TyphoonNibLoader.
- (instancetype)initWithViewControllerLoader:(id)loader andViewControllerIdentifier:(NSString*)identifier;

Previous initializer and properties were marked as deprecated, getters of properties were overrided, so we don't need to store one variable twice or make unnecessary checks.
