### PR TITLE
Fix `Incompatible block pointer types...` compile-time error in Xcode 12

### DIFF
--- a/Source/RamblerViperOpenModulePromise.h
+++ b/Source/RamblerViperOpenModulePromise.h
@@ -16,7 +16,7 @@ typedef void(^PostLinkActionBlock)(void);
  This module is used to link modules one to another. ModuleInput is typically presenter of module.
  Block can be used to return module output.
  */
-typedef id<RamblerViperModuleOutput>(^RamblerViperModuleLinkBlock)(id<RamblerViperModuleInput> moduleInput);
+typedef id<RamblerViperModuleOutput>(^RamblerViperModuleLinkBlock)(__kindof id<RamblerViperModuleInput> moduleInput);
 
 /**
  Promise used to configure module input.


### PR DESCRIPTION
Xcode 12 generates compile-time error:
`Incompatible block pointer types sending 'id<RamblerViperModuleOutput> (^)(__strong id<MyNewModuleInput>)' to parameter of type 'RamblerViperModuleLinkBlock' (aka 'id<RamblerViperModuleOutput> (^)(__strong id<RamblerViperModuleInput>)')`

Adding `__kindof` attribute for `id<RamblerViperModuleInput> moduleInput` input parameter of RamblerViperModuleLinkBlock fix this issue.